### PR TITLE
Add JTAG lock pick tiny 2 config file

### DIFF
--- a/LimeSDR-Mini_bitstreams/OpenOCD/adapters/jtag-lock-pick_tiny_2.cfg
+++ b/LimeSDR-Mini_bitstreams/OpenOCD/adapters/jtag-lock-pick_tiny_2.cfg
@@ -1,0 +1,18 @@
+#
+# DISTORTEC JTAG-lock-pick Tiny 2
+#
+# http://www.distortec.com
+#
+
+interface ftdi
+ftdi_device_desc "JTAG-lock-pick Tiny 2"
+ftdi_vid_pid 0x0403 0x8220
+
+ftdi_layout_init 0x8c28 0xff3b
+ftdi_layout_signal SWD_EN -ndata 0x0020 -oe 0x2000
+ftdi_layout_signal nTRST -data 0x0100 -noe 0x0400
+ftdi_layout_signal nSRST -data 0x0200 -noe 0x0800
+ftdi_layout_signal SWDIO_OE -ndata 0x1000
+ftdi_layout_signal LED -ndata 0x8000
+
+adapter_khz 10000


### PR DESCRIPTION
This has been tested with flashing gateware 26 into LimeSDR-mini hardware v1.1 and v1.2